### PR TITLE
chore(biome): audit rules against v2.4, add types domain and high-signal nursery rules

### DIFF
--- a/app/posts/[slug]/page.tsx
+++ b/app/posts/[slug]/page.tsx
@@ -56,14 +56,14 @@ export default async function PostPage({ params }: PageProps) {
       <Article title={meta.title} date={meta.date} dateTime={meta.dateTime}>
         <Content />
       </Article>
-      {(prev || next) && (
+      {prev || next ? (
         <section className="layout-container pb-16">
           <hr className="rule rule--strong" />
           <nav
             aria-label="Post navigation"
             className="grid grid-cols-1 md:grid-cols-2"
           >
-            {prev && (
+            {prev ? (
               <div className="grid grid-rows-[auto_1fr]">
                 <span className="eyebrow mt-6 mb-2 block">{"Older"}</span>
                 <PostCard
@@ -74,8 +74,8 @@ export default async function PostPage({ params }: PageProps) {
                   slug={prev.slug}
                 />
               </div>
-            )}
-            {next && (
+            ) : null}
+            {next ? (
               <div className="grid grid-rows-[auto_1fr] md:col-start-2">
                 <span className="eyebrow mt-6 mb-2 block">{"Newer"}</span>
                 <PostCard
@@ -86,10 +86,10 @@ export default async function PostPage({ params }: PageProps) {
                   slug={next.slug}
                 />
               </div>
-            )}
+            ) : null}
           </nav>
         </section>
-      )}
+      ) : null}
     </>
   );
 }

--- a/biome.json
+++ b/biome.json
@@ -78,13 +78,19 @@
         "useRegexpExec": "warn"
       },
       "suspicious": {
-        "noReactForwardRef": "error",
+        "noReactForwardRef": {
+          "level": "error",
+          "fix": "safe"
+        },
         "noDeprecatedImports": "error",
         "noImportCycles": "error",
         "noUnusedExpressions": "error"
       },
       "complexity": {
-        "noUselessCatchBinding": "error",
+        "noUselessCatchBinding": {
+          "level": "error",
+          "fix": "safe"
+        },
         "noUselessUndefined": "error"
       }
     }

--- a/biome.json
+++ b/biome.json
@@ -21,7 +21,8 @@
       "next": "recommended",
       "project": "recommended",
       "react": "recommended",
-      "test": "recommended"
+      "test": "recommended",
+      "types": "recommended"
     },
     "rules": {
       "correctness": {
@@ -60,7 +61,21 @@
         "noUnknownAttribute": "error",
         "noUnnecessaryConditions": "error",
         "useArraySortCompare": "error",
-        "useExhaustiveSwitchCases": "error"
+        "useExhaustiveSwitchCases": "error",
+        "noLeakedRender": "error",
+        "useNullishCoalescing": {
+          "level": "error",
+          "fix": "safe"
+        },
+        "useAwaitThenable": "error",
+        "noDuplicatedSpreadProps": "error",
+        "noSyncScripts": "error",
+        "useRequiredScripts": "error",
+        "noBeforeInteractiveScriptOutsideDocument": "error",
+        "useFind": "warn",
+        "useImportsFirst": "warn",
+        "noUnsafePlusOperands": "warn",
+        "useRegexpExec": "warn"
       },
       "suspicious": {
         "noReactForwardRef": "error",

--- a/components/Card/Card.tsx
+++ b/components/Card/Card.tsx
@@ -38,14 +38,14 @@ export const Card = ({
     <>
       <div className="flex flex-col gap-1">
         <span className="eyebrow">{eyebrow}</span>
-        {date && (
+        {date ? (
           <time
             className="font-mono text-caption text-page-text-muted"
             dateTime={date}
           >
             {formatLedgerDate(date)}
           </time>
-        )}
+        ) : null}
       </div>
       <div className="flex flex-col gap-2">
         <h3
@@ -57,14 +57,14 @@ export const Card = ({
           {title}
           {trailing}
         </h3>
-        {hostTag && (
+        {hostTag ? (
           <span className="font-mono text-caption text-page-text-muted">
             {hostTag}
           </span>
-        )}
-        {description && (
+        ) : null}
+        {description ? (
           <p className="max-w-prose text-page-text-muted">{description}</p>
-        )}
+        ) : null}
       </div>
       {index !== undefined && <LedgerIndex value={index} />}
     </>

--- a/components/Code/Code.tsx
+++ b/components/Code/Code.tsx
@@ -15,7 +15,9 @@ interface CodeProps {
 }
 
 export function CodeView({ highlighted }: { highlighted: HighlightedCode }) {
-  const nameMatch = highlighted?.meta?.match(/^name="([^"]+)"$/);
+  const nameMatch = highlighted?.meta
+    ? /^name="([^"]+)"$/.exec(highlighted.meta)
+    : null;
   const displayMeta = nameMatch ? nameMatch[1] : highlighted.meta;
 
   return (

--- a/components/Code/codehike-handlers.tsx
+++ b/components/Code/codehike-handlers.tsx
@@ -122,11 +122,11 @@ export const calloutHandler: AnnotationHandler = {
       title={annotation.query}
     >
       {children}
-      {annotation.query && (
+      {annotation.query ? (
         <span className="absolute top-full left-0 z-10 mt-2 hidden whitespace-nowrap rounded border border-code-border bg-code-bg p-2 text-code-text text-sm shadow-lg group-hover:block">
           {annotation.query}
         </span>
-      )}
+      ) : null}
     </span>
   ),
 };

--- a/tokens/stories/TokenRow.tsx
+++ b/tokens/stories/TokenRow.tsx
@@ -39,11 +39,11 @@ export const TokenRow = ({ token }: TokenRowProps) => {
       {/* Column 1: Token name and description */}
       <div className="flex flex-col gap-1">
         <code className={styles.name}>{token.name}</code>
-        {token.comment && (
+        {token.comment ? (
           <p className="mt-1 text-page-text-muted text-sm leading-snug">
             {token.comment}
           </p>
-        )}
+        ) : null}
       </div>
 
       {/* Column 2: Light value */}

--- a/tokens/stories/visualizers/ColorSwatch.tsx
+++ b/tokens/stories/visualizers/ColorSwatch.tsx
@@ -12,8 +12,8 @@ export const ColorSwatch = ({ value, label }: ColorSwatchProps) => (
   <div
     className="h-12 w-12 shrink-0 rounded border border-black/10 dark:border-white/10"
     style={{ backgroundColor: value }}
-    title={label || value}
+    title={label ?? value}
     role="img"
-    aria-label={label || `Color: ${value}`}
+    aria-label={label ?? `Color: ${value}`}
   />
 );

--- a/tokens/stories/visualizers/SpacingBar.tsx
+++ b/tokens/stories/visualizers/SpacingBar.tsx
@@ -39,9 +39,9 @@ export const SpacingBar = ({ value, label }: SpacingBarProps) => {
         <div
           className={barClasses}
           style={{ width: `${cappedWidth}px` }}
-          title={label || value}
+          title={label ?? value}
           role="img"
-          aria-label={label || `Spacing: ${value}`}
+          aria-label={label ?? `Spacing: ${value}`}
         />
       );
     }
@@ -51,9 +51,9 @@ export const SpacingBar = ({ value, label }: SpacingBarProps) => {
       <div
         className={barClasses}
         style={{ width: value }}
-        title={label || value}
+        title={label ?? value}
         role="img"
-        aria-label={label || `Spacing: ${value}`}
+        aria-label={label ?? `Spacing: ${value}`}
       />
     );
   };

--- a/tokens/stories/visualizers/TypographyPreview.tsx
+++ b/tokens/stories/visualizers/TypographyPreview.tsx
@@ -16,9 +16,9 @@ export const TypographyPreview = ({ value, label }: TypographyPreviewProps) => {
   return (
     <div
       className="flex h-12 min-w-20 items-center overflow-hidden"
-      title={label || value}
+      title={label ?? value}
       role="img"
-      aria-label={label || `Typography: ${value}`}
+      aria-label={label ?? `Typography: ${value}`}
     >
       <span
         className="font-semibold text-page-text-body leading-none"


### PR DESCRIPTION
## Summary

Audited the Biome config against what's stabilised in 2.4 and what's worth pulling from nursery. Two small but meaningful outcomes:

- The `types` domain was split out of `project` in 2.4. Adding it means `noMisusedPromises` and `noFloatingPromises` now actually run type inference instead of registering as no-ops.
- Opted into the nursery rules that catch real bugs for this stack (React 19 + Next 16): `noLeakedRender`, `useNullishCoalescing`, `useAwaitThenable`, `noDuplicatedSpreadProps`, plus the Next script-safety trio. Four more idiomatic rules added as warnings.

Along the way, fixed the 16 violations that surfaced: `||` with nullable props changed to `??`, `&&` JSX guards over non-boolean operands rewritten as ternaries, one stray non-global `.match()` switched to `.exec()`.

Second commit flips the fix mode on `noUselessCatchBinding` and `noReactForwardRef` to `safe` so future occurrences auto-apply. Left genuinely risky auto-fixes (`useSortedClasses`, `useExhaustiveDependencies`, `useExhaustiveSwitchCases`, `noFloatingPromises`) as unsafe.

## Test plan

- [ ] `pnpm lint` passes clean
- [ ] `pnpm exec tsc --noEmit` clean
- [ ] Spot check: card/post-nav ternary rewrites render identically in the browser
- [ ] Confirm CodeHike frame title still reads the `name="..."` meta correctly