### PR TITLE
chore(vscode): workspace config for tasks, debug, and editor ergonomics

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,13 @@
+{
+  "recommendations": [
+    "biomejs.biome",
+    "bradlc.vscode-tailwindcss",
+    "unifiedjs.vscode-mdx",
+    "vitest.explorer",
+    "ms-playwright.playwright"
+  ],
+  "unwantedRecommendations": [
+    "esbenp.prettier-vscode",
+    "dbaeumer.vscode-eslint"
+  ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -24,6 +24,43 @@
         "uriFormat": "%s",
         "action": "debugWithEdge"
       }
+    },
+    {
+      "name": "Vitest: debug current file",
+      "type": "node",
+      "request": "launch",
+      "runtimeExecutable": "pnpm",
+      "runtimeArgs": ["vitest", "run", "${relativeFile}"],
+      "console": "integratedTerminal",
+      "smartStep": true
+    },
+    {
+      "name": "Vitest: debug all",
+      "type": "node",
+      "request": "launch",
+      "runtimeExecutable": "pnpm",
+      "runtimeArgs": ["vitest", "run"],
+      "console": "integratedTerminal"
+    },
+    {
+      "name": "Storybook: dev",
+      "type": "node",
+      "request": "launch",
+      "runtimeExecutable": "pnpm",
+      "runtimeArgs": ["storybook"],
+      "serverReadyAction": {
+        "pattern": "Local:\\s+(https?://\\S+)",
+        "uriFormat": "%s",
+        "action": "debugWithEdge"
+      }
+    },
+    {
+      "name": "Storybook: test-storybook",
+      "type": "node",
+      "request": "launch",
+      "runtimeExecutable": "pnpm",
+      "runtimeArgs": ["test-storybook"],
+      "console": "integratedTerminal"
     }
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -48,5 +48,27 @@
     "package.json": "pnpm-lock.yaml, pnpm-workspace.yaml, .npmrc",
     "tsconfig.json": "tsconfig.*.json, tsconfig.tsbuildinfo",
     "next.config.ts": "next-env.d.ts, middleware.ts, instrumentation.ts"
+  },
+  "tailwindCSS.experimental.classRegex": [
+    ["cn\\(([^)]*)\\)", "[\"'`]([^\"'`]*).*?[\"'`]"]
+  ],
+  "tailwindCSS.includeLanguages": {
+    "mdx": "html"
+  },
+  "tailwindCSS.classAttributes": ["class", "className", "ngClass"],
+  "typescript.preferences.importModuleSpecifier": "non-relative",
+  "typescript.preferences.preferTypeOnlyAutoImports": true,
+  "javascript.preferences.importModuleSpecifier": "non-relative",
+  "[mdx]": {
+    "editor.formatOnSave": false,
+    "editor.wordWrap": "on",
+    "editor.quickSuggestions": {
+      "comments": false,
+      "strings": true,
+      "other": true
+    }
+  },
+  "[css]": {
+    "editor.defaultFormatter": "vscode.css-language-features"
   }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -24,5 +24,29 @@
   },
   "[jsonc]": {
     "editor.defaultFormatter": "biomejs.biome"
+  },
+  "files.exclude": {
+    "**/.DS_Store": true,
+    "**/tsconfig.tsbuildinfo": true
+  },
+  "search.exclude": {
+    "generated/**": true,
+    ".next/**": true,
+    "storybook-static/**": true,
+    "pnpm-lock.yaml": true,
+    "coverage/**": true
+  },
+  "files.readonlyInclude": {
+    "generated/**": true
+  },
+  "files.associations": {
+    "*.mdx": "mdx"
+  },
+  "explorer.fileNesting.enabled": true,
+  "explorer.fileNesting.patterns": {
+    "*.tsx": "${capture}.module.css, ${capture}.stories.tsx, ${capture}.test.tsx",
+    "package.json": "pnpm-lock.yaml, pnpm-workspace.yaml, .npmrc",
+    "tsconfig.json": "tsconfig.*.json, tsconfig.tsbuildinfo",
+    "next.config.ts": "next-env.d.ts, middleware.ts, instrumentation.ts"
   }
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -28,6 +28,65 @@
           }
         ]
       }
+    },
+    {
+      "label": "typecheck",
+      "type": "shell",
+      "command": "pnpm typecheck",
+      "problemMatcher": "$tsc",
+      "group": "test",
+      "presentation": {
+        "reveal": "silent",
+        "panel": "dedicated"
+      }
+    },
+    {
+      "label": "typecheck: watch",
+      "type": "shell",
+      "command": "pnpm typecheck --watch",
+      "isBackground": true,
+      "problemMatcher": "$tsc-watch",
+      "presentation": {
+        "reveal": "silent",
+        "panel": "dedicated"
+      }
+    },
+    {
+      "label": "tokens: build",
+      "type": "shell",
+      "command": "pnpm tokens"
+    },
+    {
+      "label": "next: dev",
+      "type": "shell",
+      "command": "pnpm dev",
+      "isBackground": true,
+      "presentation": {
+        "panel": "dedicated"
+      }
+    },
+    {
+      "label": "storybook: dev",
+      "type": "shell",
+      "command": "pnpm storybook",
+      "isBackground": true,
+      "presentation": {
+        "panel": "dedicated"
+      }
+    },
+    {
+      "label": "test-storybook",
+      "type": "shell",
+      "command": "pnpm test-storybook"
+    },
+    {
+      "label": "dev: everything",
+      "dependsOn": ["next: dev", "storybook: dev", "typecheck: watch"],
+      "dependsOrder": "parallel",
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      }
     }
   ]
 }


### PR DESCRIPTION
## Summary

Adds a workspace-scoped `.vscode/` config so the editor matches how this repo is actually built and tested.

- Recommended/unwanted extensions for new contributors (and to keep noisy ones out)
- Editor settings: file nesting, readonly `generated/`, Tailwind/MDX/CSS language wiring, import-alias resolution
- Tasks: `dev`, `build`, `typecheck`, `tokens`, Storybook (dev + test)
- Launch configs for Vitest and Storybook, plus a compound `dev` config

No runtime or product code touched; all changes live under `.vscode/`.

## Test plan

- [ ] Open the workspace fresh, accept the recommended extensions prompt
- [ ] Run each task from the Command Palette and confirm it executes
- [ ] Confirm the `dev` compound launch config starts Next + Storybook
- [ ] Verify Tailwind class IntelliSense works in `.tsx` and `.mdx`
- [ ] Verify `generated/` is read-only in the editor