### PR TITLE
fix: resolve broken links in HTTP/2 post

### DIFF
--- a/content/posts/why-you-should-be-using-http-2-and-https/page.mdx
+++ b/content/posts/why-you-should-be-using-http-2-and-https/page.mdx
@@ -18,12 +18,10 @@ Previously, SSL certificates did require a tiny investment. That changes with th
 
 ## HTTP/2 or h2
 
-HTTPS is not itself faster than HTTP, but with h2 (HTTP/2) it absolutely is, and it’s [only available for HTTPS ](http://caniuse.com/#search=http2)connections.
+HTTPS is not itself faster than HTTP, but with h2 (HTTP/2) it absolutely is, and it’s [only available for HTTPS](https://caniuse.com/http2) connections.
 
 <Image
-  src={browserSupportHttpsH2.src}
-  width={700}
-  height={348}
+  src={browserSupportHttpsH2}
   alt="Browser Support for HTTP/2 on HTTPS"
 />
 
@@ -72,9 +70,7 @@ Chrome from version 52, will be displaying an ‘i’ mark for all HTTP pages. T
 Technically the symbol stands for _information_, but I’m not so sure visitors will interpret it that way.
 
 <Image
-  src={chromeSecurityIconHttp.src}
-  width={1314}
-  height={594}
+  src={chromeSecurityIconHttp}
   alt="Chrome security icon overview"
 />
 


### PR DESCRIPTION
## Summary

- Pass imported `StaticImageData` directly to `next/image` instead of `image.src`, so the link checker no longer interprets the JSX expression as a relative file URL.
- Replace the dead `caniuse.com/#search=http2` fragment with the canonical `https://caniuse.com/http2`.

Closes #26

## Test plan

- [ ] CI link check passes on the next scheduled run
- [ ] Post renders with images at `/posts/why-you-should-be-using-http-2-and-https`