### PR TITLE
Fix weekly link checker false positives from MDX Image tags

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -26,6 +26,9 @@ jobs:
           key: lychee-cache-${{ github.run_id }}
           restore-keys: lychee-cache-
 
+      # --scheme limits checks to external links; without it lychee parses MDX
+      # <Image src={expression} /> attributes as local file paths and reports
+      # "Cannot find file" false positives.
       - name: Run lychee
         id: lychee
         uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2
@@ -35,6 +38,8 @@ jobs:
             --max-cache-age 7d
             --no-progress
             --include-fragments
+            --scheme https
+            --scheme http
             './content/posts/**/*.mdx'
           fail: false
           output: lychee-report.md


### PR DESCRIPTION
## Problem

The weekly Link Check workflow has opened a "broken links detected" issue every Monday (#31, #34, #36, #38, #40, #42, #44, #47, #50, #51, ...) reporting two `Cannot find file` errors in `content/posts/why-you-should-be-using-http-2-and-https/page.mdx`.

Both errors are false positives. lychee's HTML parser reads the MDX JSX image tags:

```jsx
``&lt;Image src={browserSupportHttpsH2} /&gt;``
``&lt;Image src={chromeSecurityIconHttp} /&gt;``
```

and treats the `{expression}` attribute values as relative file links, then fails to find a file literally named `{browserSupportHttpsH2}`. The actual PNGs exist and are referenced via ES imports, which lychee doesn't understand.

This accounts exactly for the report numbers: the posts contain 10 real external links (all passing) + 2 JSX `src` expressions (always failing) = the 12 total links in every weekly report.

## Fix

Add `--scheme https --scheme http` to the lychee args so only external links are checked. Scheme-filtered links are excluded rather than errored, so the JSX pseudo-links no longer produce failures — for this post or any future post using `<Image>`. External link-rot checking (the reason this job exists) is unchanged, including `--include-fragments`.

## Testing

- Verified both referenced PNGs exist in the post directory (confirming false positive)
- Verified `--scheme` is a repeatable lychee flag and that non-matching schemes are excluded, not failed, per lychee docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016hzCffJGZ1Dx46zQ6iqQwG

---
_Generated by [Claude Code](https://claude.ai/code/session_016hzCffJGZ1Dx46zQ6iqQwG)_